### PR TITLE
Fixed a bug in add_message_to_send_queue() that caused server to fail…

### DIFF
--- a/pyIGTLink/pyIGTLink.py
+++ b/pyIGTLink/pyIGTLink.py
@@ -93,7 +93,7 @@ class PyIGTLink(SocketServer.TCPServer):
         else:
             if len(self.message_queue) > 0:
                 with self.lock_server_thread:
-                    self.message_queue = collections.clear()
+                    self.message_queue.clear()
         return True
 
     def _signal_handler(self, signum, stackframe):


### PR DESCRIPTION
… when a client attempts to reconnect after a disconnect event has previously occurred. The bug is triggered if there is still data in the queue when a client disconnect event occurs and the client then attempts to reconnect to the server. At low data rates the queue is typically empty when the disconnect event occurs which results in the bug not getting triggered.